### PR TITLE
Custom placeholder on Activities

### DIFF
--- a/src/components/Activity.js
+++ b/src/components/Activity.js
@@ -33,6 +33,7 @@ type Props = {|
   onPressAvatar?: () => mixed,
   sub?: string,
   icon?: string,
+  avatarPlaceholder?: string,
   activity: ActivityData,
   /** Width of an image that's displayed, by default this is
    * the width of the screen */
@@ -100,6 +101,7 @@ export default class Activity extends React.Component<Props> {
         <UserBar
           username={actor.data.name}
           avatar={actor.data.profileImage}
+          avatarPlaceholder={this.props.avatarPlaceholder}
           subtitle={this.props.sub}
           timestamp={time}
           icon={this.props.icon}

--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -12,6 +12,7 @@ import type { UserResponse } from 'getstream';
 export type Props = {|
   /** The image source or a getter fn */
   source: ?string | ((activeUser: UserResponse<Object>) => ?string),
+  avatarPlaceholder?: string,
   size?: number,
   editButton?: boolean,
   noShadow?: boolean,
@@ -49,43 +50,63 @@ export default class Avatar extends React.Component<Props> {
 
 type InnerProps = {| ...Props, source: ?string |};
 
-const AvatarInner = (props: InnerProps) => {
-  const {
-    source,
-    size = 200,
-    noShadow,
-    notRound,
-    editButton,
-    onUploadButtonPress,
-  } = props;
-  const styles = buildStylesheet('avatar', props.styles || {});
-  const borderRadius = notRound ? undefined : size / 2;
-  return (
-    <View
-      style={[
-        styles.container,
-        noShadow ? styles.noShadow : null,
-        {
-          width: size,
-          height: size,
-        },
-      ]}
-    >
-      <Image
+
+class AvatarInner extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isImageError: false
+    };
+  }
+
+  render() {
+    let {
+      source,
+      size = 200,
+      noShadow,
+      notRound,
+      editButton,
+      onUploadButtonPress,
+      avatarPlaceholder
+    } = this.props;
+
+    let styles = buildStylesheet("avatar", this.props.styles || {});
+    let borderRadius = notRound ? undefined : size / 2;
+
+    return (
+      <View
         style={[
-          styles.image,
+          styles.container,
+          noShadow ? styles.noShadow : null,
           {
             width: size,
-            height: size,
-            borderRadius,
-          },
+            height: size
+          }
+          , this.state.isImageError ? { marginRight: 10 }: null
         ]}
-        source={source ? { uri: source } : require('../images/placeholder.png')}
-        resizeMethod="resize"
-      />
-      {editButton ? (
-        <UploadImage onUploadButtonPress={onUploadButtonPress} />
-      ) : null}
-    </View>
-  );
-};
+      >
+        <Image
+          style={[
+            styles.image,
+            {
+              width: size,
+              height: size,
+              borderRadius: borderRadius
+            }
+          ]}
+          source={
+            source && !this.state.isImageError
+              ? { uri: source}
+              : avatarPlaceholder ? avatarPlaceholder : require( "../images/placeholder.png")
+          }
+          onError={() => {
+            this.setState({ isImageError: true });
+          }}
+        />
+        {editButton ? (
+          <UploadImage onUploadButtonPress={onUploadButtonPress} />
+        ) : null}
+      </View>
+    );
+  }
+}

--- a/src/components/UserBar.js
+++ b/src/components/UserBar.js
@@ -11,6 +11,7 @@ import { buildStylesheet } from '../styles';
 type Props = {|
   username: ?string,
   avatar?: string,
+  avatarPlaceholder?: string,
   subtitle?: string,
   time?: string, // text that should be displayed as the time
   timestamp?: string | number, // a timestamp that should be humanized
@@ -31,6 +32,7 @@ const UserBar = ({
   avatar,
   follow,
   onPressAvatar,
+  avatarPlaceholder,
   icon,
   ...props
 }: Props) => {
@@ -48,6 +50,7 @@ const UserBar = ({
         <TouchableOpacity onPress={onPressAvatar} disabled={!onPressAvatar}>
           <Avatar
             source={avatar}
+            avatarPlaceholder={avatarPlaceholder}
             size={48}
             noShadow
             styles={


### PR DESCRIPTION
If the user didn't have an avatar it would show the Stream placeholder, but if the url of the avatar wasn't working it would show no image at all. 
I've added avatarPlaceholder prop on the Activity, Avatar and Userbar to show a custom placeholder. 

I've also fixed the problem when the url doesn't work and there is no custom placeholder it shows the Stream placeholder.