### PR TITLE
Change the import statement of FlatFeed in SinglePost.js

### DIFF
--- a/src/components/SinglePost.js
+++ b/src/components/SinglePost.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 
-import { FlatFeed } from '..';
+import FlatFeed from './FlatFeed';
 
 import type { FeedRequestOptions } from 'getstream';
 import type {


### PR DESCRIPTION
I was getting the error below, it was caused by the way FlatFeed being imported. In my app, when using `import { FlatFeed } from '..';`, `..` turned out to be an empty object, so it couldn't find FlatFeed.

```
Invariant Violation: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.

Check the render method of `SinglePost`.

This error is located at:
    in SinglePost (created by TopicContainer)
    in StreamApp (created by TopicContainer)
    in RCTView (at View.js:45)
    in View (at view/index.js:47)
    in View (at forwardRef.js:6)
    in View (at asBaseComponent.js:22)
    in View (at forwardRef.js:6)
    in View (created by TopicContainer)
    in TopicContainer (created by Context.Consumer)
    in ThemeProvider (created by Context.Consumer)
    in withTheme(TopicContainer) (created by Context.Consumer)
    in ThemeProvider (created by Context.Consumer)
    in withTheme(withTheme(TopicContainer))
    in ThemeProvider (at provider.js:10)
    in Provider (at provider.js:9)
    in ProviderWrapper
    in Unknown (at ComponentWrapper.js:29)
    in WrappedComponent (at renderApplication.js:35)
    in RCTView (at View.js:45)
    in View (at AppContainer.js:98)
    in RCTView (at View.js:45)
    in View (at AppContainer.js:115)
    in AppContainer (at renderApplication.js:34)

createFiberFromTypeAndProps
    ReactNativeRenderer-dev.js:5715:8
createFiberFromElement
    ReactNativeRenderer-dev.js:5743:14
reconcileSingleElement
    ReactNativeRenderer-dev.js:9000:22
reconcileChildFibers
    ReactNativeRenderer-dev.js:9084:12
reconcileChildren
    ReactNativeRenderer-dev.js:10993:27
finishClassComponent
    ReactNativeRenderer-dev.js:11607:4
updateClassComponent
    ReactNativeRenderer-dev.js:11508:23
beginWork
    ReactNativeRenderer-dev.js:12874:13
performUnitOfWork
    ReactNativeRenderer-dev.js:17276:11
```