### PR TITLE
Test against node 10 instead of node 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 9
+  - 10
   - 8
 before_script:
   - cd example && yarn install


### PR DESCRIPTION
Node 9 has been failing CI for this project for a while due to things like:

> The engine "node" is incompatible with this module. Expected version "^8.16.0 || ^10.6.0 || >=11.0.0". Got "9.11.2"

We might as well try with Node 10 instead?