### PR TITLE
Remove console.log statement from ReactionList.js

### DIFF
--- a/src/components/ReactionList.js
+++ b/src/components/ReactionList.js
@@ -174,7 +174,6 @@ class ReactionListInner extends React.Component<PropsInner> {
     //     )
     //   }
     // />
-    console.log();
     return (
       <React.Fragment>
         {this.props.children}


### PR DESCRIPTION
This was introduced in 96396ec6b8bc89535b920a627aadef928917b6bc for some reason.