### PR TITLE
Add missing key attribute to Text inside Activity

### DIFF
--- a/src/components/Activity.js
+++ b/src/components/Activity.js
@@ -182,7 +182,7 @@ export default class Activity extends React.Component<Props> {
           </Text>,
         );
       } else {
-        rendered.push(<Text style={styles.text}>{tokens[i] + ' '}</Text>);
+        rendered.push(<Text key={i} style={styles.text}>{tokens[i] + ' '}</Text>);
       }
     }
     return rendered;

--- a/src/components/Activity.js
+++ b/src/components/Activity.js
@@ -182,7 +182,11 @@ export default class Activity extends React.Component<Props> {
           </Text>,
         );
       } else {
-        rendered.push(<Text key={i} style={styles.text}>{tokens[i] + ' '}</Text>);
+        rendered.push(
+          <Text key={i} style={styles.text}>
+            {tokens[i] + ' '}
+          </Text>,
+        );
       }
     }
     return rendered;


### PR DESCRIPTION
Fixes the child should have unique key error on Home.

```
Warning: Each child in a list should have a unique "key" prop.

Check the top-level render call using <Text>. See https://fb.me/react-warning-keys for more information.
    in Text (at Activity.js:185)
    in Unknown (at utils.js:37)
    in div (created by View)
    in View (created by TouchableOpacity)
    in TouchableOpacity (at Activity.js:264)
    in Activity (at HomeScreen.tsx:60)
    in div (created by View)
    in View (created by TouchableOpacity)
    in TouchableOpacity (at HomeScreen.tsx:59)
    in Activity (at utils.js:37)
    in ImmutableItemWrapper (at FlatFeed.js:133)
    in div (created by View)
    in View (created by CellRenderer)
    in CellRenderer (created by VirtualizedList)
    in div (created by View)
    in View (created by ScrollView)
```