### PR TITLE
Export Feed, StreamContext, and FeedContext

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 // @flow
-export { StreamApp } from './Context';
+export { StreamApp, StreamContext, Feed, FeedContext } from './Context';
 export type { AppCtx, FeedCtx } from './Context';
 
 export * from './types';


### PR DESCRIPTION
Using the render prop components for context is messy and a hassle.

Expose `StreamContext` and `FeedContext` so we can use `useContext`, or export hooks from the library itself.

Also expose `Feed` to give more control over feeds.