### PR TITLE
Use latest expo permissions packages

### DIFF
--- a/expo-package/src/index.js
+++ b/expo-package/src/index.js
@@ -1,6 +1,7 @@
 // @flow
 import { registerNativeHandlers } from 'react-native-activity-feed-core';
-import { ImagePicker, Permissions } from 'expo';
+import * as Permissions from 'expo-permissions';
+import * as ImagePicker from 'expo-image-picker';
 registerNativeHandlers({
   pickImage: async () => {
     await Permissions.askAsync(Permissions.CAMERA_ROLL);


### PR DESCRIPTION
`ImagePicker` and `Permissions` are no longer available from the `expo` package. They must be imported separately.

Fixes #153. 