### PR TITLE
Android image upload fix

### DIFF
--- a/src/components/StatusUpdateForm.js
+++ b/src/components/StatusUpdateForm.js
@@ -193,15 +193,18 @@ class StatusUpdateFormInner extends React.Component {
 
     let response;
     let contentType;
+    let type;
     if (Platform.OS === 'android') {
       const filename = result.uri.replace(/^(file:\/\/|content:\/\/)/, '');
       contentType = mime.lookup(filename) || 'application/octet-stream';
+      type = contentType;
     }
     try {
       response = await this.props.client.images.upload(
         result.uri,
         null,
         contentType,
+        type
       );
     } catch (e) {
       console.warn(e);

--- a/src/components/StatusUpdateForm.js
+++ b/src/components/StatusUpdateForm.js
@@ -204,7 +204,7 @@ class StatusUpdateFormInner extends React.Component {
         result.uri,
         null,
         contentType,
-        type
+        type,
       );
     } catch (e) {
       console.warn(e);


### PR DESCRIPTION
We were getting a 'Network Error' when trying to upload an image. The solution we found was passing a type parameter to the upload, similarly of how it was fixed on stream chat: https://github.com/GetStream/stream-chat-js/pull/464/files