### PR TITLE
Adds textProps prop for additional customization in ReactionIcon

### DIFF
--- a/src/components/ReactionIcon.js
+++ b/src/components/ReactionIcon.js
@@ -66,11 +66,13 @@ const ReactionIcon = withTranslationContext((props) => {
     dimensions.width = props.width;
   }
 
+  const textProps = props.textProps ?? {}
+
   return (
     <TouchableOpacity style={styles.container} onPress={props.onPress}>
       <Image source={props.icon} style={[styles.image, dimensions]} />
       {count != null ? (
-        <Text style={styles.text}>{defaultLabelFunction(count, props)}</Text>
+        <Text style={styles.text} {...textProps}>{defaultLabelFunction(count, props)}</Text>
       ) : null}
     </TouchableOpacity>
   );
@@ -105,6 +107,8 @@ ReactionIcon.propTypes = {
    * @param {object} param
    */
   labelFunction: PropTypes.func,
+  /** Additional props to the text component */
+  textProps: PropTypes.object,
 };
 
 export default ReactionIcon;


### PR DESCRIPTION
While adding the capability of restricting and allowing enlarging the font size in our app, we found out that the `ReactionIcon` component didn't have the option to receive props for its child `Text` (in our case `allowFontSize` or `maxFontSizeMultiplier`).

This is the use case:

```js
<ReactionIcon
    ...
    textProps={{
      maxFontSizeMultiplier: MAX_FONT_SIZE_MULTIPLIER,
    }}
 />
```

with `const MAX_FONT_SIZE_MULTIPLIER = 1.4`:
<p align="center">
<img src="https://user-images.githubusercontent.com/20881388/174657062-1e1b5031-c591-4d54-9e4f-f23c29657be9.png" width="300">
</p>

